### PR TITLE
fix: Skip installation if component plan not approved

### DIFF
--- a/config/samples/example-test.sh
+++ b/config/samples/example-test.sh
@@ -323,7 +323,7 @@ waitComponentSatus "kubebb-system" "repository-grafana-sample-image.grafana"
 
 info "4.2 create grafana subscription"
 kubectl apply -f config/samples/core_v1alpha1_grafana_subscription.yaml
-getPodImage "kubebb-system" "app.kubernetes.io/name=grafana" "192.168.1.1:5000/grafana-local/grafana:9.5.3"
+getPodImage "kubebb-system" "app.kubernetes.io/name=grafana" "192.168.1.1:5000/grafana-local/grafana"
 kubectl delete -f config/samples/core_v1alpha1_grafana_subscription.yaml
 
 info "all finished! ✅"

--- a/controllers/componentplan_controller.go
+++ b/controllers/componentplan_controller.go
@@ -271,7 +271,10 @@ func (r *ComponentPlanReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, r.PatchCondition(ctx, plan, logger, corev1alpha1.ComponentPlanInstallSuccess())
 		}
 	}
-
+	if !plan.Spec.Approved {
+		logger.Info("component plan not approved, skip install...")
+		return ctrl.Result{}, nil
+	}
 	logger.Info("install the component plan...")
 	switch manifest.Labels[string(corev1alpha1.ComponentPlanTypeInstalled)] {
 	case "":


### PR DESCRIPTION
Update componentplan_controller.go to check if the plan is approved before installing, and update example-test.sh with a correct Grafana image.

This change ensures that the component plan is not installed until it has been approved, providing better control and minimizing unnecessary installations. Also, the example script now uses the correct Grafana image for testing purposes.

Signed-off-by: Abirdcfly <fp544037857@gmail.com>