### PR TITLE
Add Goreleaser configuration and GitHub action for releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,45 @@
+name: goreleaser
+
+on:
+  push:
+    # run only against tags.
+    tags:
+      - 'v*'
+env:
+  GO_VER: 1.20
+  GO_TAGS: ""
+permissions:
+  contents: write
+  # packages: write
+  # issues: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: git fetch --force --tags
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: "go.mod"
+      # More assembly might be required: Docker logins, GPG, etc. It all depends
+      # on your needs.
+      - name: Login to the dockerhub Registry
+        uses: docker/login-action@v2
+        with:
+          username: kubebb
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - uses: goreleaser/goreleaser-action@v4
+        with:
+          # either 'goreleaser' (default) or 'goreleaser-pro':
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Your GoReleaser Pro key, if you are using the 'goreleaser-pro'
+          # distribution:
+          # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,90 @@
+# Make sure to check the documentation at https://goreleaser.com
+builds:
+  - env:
+      - CGO_ENABLED=0
+    binary: manager
+    id: manager
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+dockers:
+  - use: buildx
+    image_templates:
+      - "kubebb/core:v{{ .Version }}-amd64"
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version=v{{.Version}}"
+      - "--build-arg=GO_VER={{.Env.GO_VER}}"
+      - "--build-arg=GO_TAGS={{.Env.GO_TAGS}}"
+#      - "--build-arg=BUILD_ID={{.Env.SEMREV_LABEL}}"  #todo
+#      - "--build-arg=BUILD_DATE={{.Env.BUILD_DATE}}"  #todo
+      - "--platform=linux/amd64"
+    dockerfile: goreleaser.dockefile
+  - use: buildx
+    image_templates:
+        - "kubebb/core:v{{ .Version }}-arm64v8"
+    build_flag_templates:
+        - "--pull"
+        - "--label=org.opencontainers.image.created={{.Date}}"
+        - "--label=org.opencontainers.image.title={{.ProjectName}}"
+        - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+        - "--label=org.opencontainers.image.version=v{{.Version}}"
+        - "--build-arg=GO_VER={{.Env.GO_VER}}"
+        - "--build-arg=GO_TAGS={{.Env.GO_TAGS}}"
+        #      - "--build-arg=BUILD_ID={{.Env.SEMREV_LABEL}}"  #todo
+        #      - "--build-arg=BUILD_DATE={{.Env.BUILD_DATE}}"  #todo
+        - "--platform=linux/arm64"
+    dockerfile: goreleaser.dockefile
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  use: github
+  groups:
+    - title: New Features
+      regexp: "^.*feat[(\\w)]*:+.*$"
+      order: 0
+    - title: 'Bug Fixes'
+      regexp: "^.*fix[(\\w)]*:+.*$"
+      order: 1
+    - title: Others
+      order: 999
+  filters:
+    exclude:
+      - '^Merge pull request'
+release:
+  draft: true
+  replace_existing_draft: false
+  mode: append
+  header: |
+    ## {{.ProjectName}}-v{{.Version}}
+
+    Welcome to this new release!
+    
+    ### Images built for this release:
+    core: `kubebb/core:v{{ .Version }}`
+    
+    ### Breaking Changes:
+    None
+    
+    ### Feature summary 🚀 🚀 🚀
+    TODO
+  footer: |
+    ## Thanks to our Contributors!
+    
+    Thank you to everyone who contributed to {{.Tag}}! ❤️
+
+    And thank you very much to everyone else not listed here who contributed in other ways like filing issues, giving feedback, testing fixes, helping users in slack, etc. 🙏
+  name_template: "v{{.Version}}"
+docker_manifests:
+  - name_template: "kubebb/core:v{{ .Version }}"
+    image_templates:
+      - "kubebb/core:v{{ .Version }}-amd64"
+      - "kubebb/core:v{{ .Version }}-arm64v8"
+    skip_push: false
+    use: docker

--- a/goreleaser.dockefile
+++ b/goreleaser.dockefile
@@ -1,0 +1,8 @@
+FROM alpine/helm:latest as helm
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=helm /usr/bin/helm /usr/bin/helm
+COPY manager .
+USER 65532:65532
+
+ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Implemented Goreleaser configuration to automate release process ensuring that it is consistent, repeatable, and reliable. A new `.goreleaser.yaml` file is added for organizing build, Docker image creation and pushing to Dockerhub, and program versioning. Also included custom templates for structuring of release notes. New GitHub action workflow `release.yaml` has also been added, it's triggered by pushing tags and performs the release using Goreleaser. This improvement eliminates the need for manual compilation and publishing thus increasing the efficiency of the release process.

Fix #70 