### PR TITLE
fix: use NamespacedName as the helm repo name

### DIFF
--- a/api/v1alpha1/repository.go
+++ b/api/v1alpha1/repository.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
 	"os"
 	"strings"
 )
@@ -30,6 +31,11 @@ const (
 
 	ComponentRepositoryLabel = "kubebb.component.repository"
 )
+
+// NamespacedName return the namespaced name of the repository in string format
+func (repo *Repository) NamespacedName() string {
+	return fmt.Sprintf("%s.%s", repo.GetNamespace(), repo.GetName())
+}
 
 // IsPullStrategySame Determine whether the contents of two structures are the same
 func IsPullStrategySame(a, b *PullStategy) bool {

--- a/controllers/componentplan_controller.go
+++ b/controllers/componentplan_controller.go
@@ -191,7 +191,8 @@ func (r *ComponentPlanReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			logger.Error(err, "Failed to get Repository")
 			return ctrl.Result{Requeue: true}, r.PatchCondition(ctx, plan, logger, corev1alpha1.ComponentPlanInstallFailed(err))
 		}
-		repoName := repo.Name
+		// Note: repoName should be in namepsaced to avoid confilicts when same repo name in different namespaces are used
+		repoName := repo.NamespacedName()
 		repoUrl := repo.Spec.URL
 		if repoUrl == "" {
 			err = errors.New("repo url is empty")

--- a/pkg/helm/cmd.go
+++ b/pkg/helm/cmd.go
@@ -108,11 +108,18 @@ func GetManifests(ctx context.Context, cli client.Client, logger logr.Logger, na
 		}
 
 		var targets []*unstructured.Unstructured
+		var appendTarget = func(obj *unstructured.Unstructured) {
+			if obj == nil {
+				return
+			}
+			obj.SetNamespace(namespace)
+			targets = append(targets, obj)
+		}
 		if obj.IsList() {
 			err = obj.EachListItem(func(object runtime.Object) error {
 				unstructuredObj, ok := object.(*unstructured.Unstructured)
 				if ok {
-					targets = append(targets, unstructuredObj)
+					appendTarget(unstructuredObj)
 					return nil
 				}
 				return fmt.Errorf("resource list item has unexpected type")
@@ -123,7 +130,7 @@ func GetManifests(ctx context.Context, cli client.Client, logger logr.Logger, na
 		} else if utils.IsNullList(obj) {
 			// noop
 		} else {
-			targets = []*unstructured.Unstructured{obj}
+			appendTarget(obj)
 		}
 
 		manifests = append(manifests, targets...)

--- a/pkg/repository/chartmuseum.go
+++ b/pkg/repository/chartmuseum.go
@@ -70,14 +70,15 @@ func NewChartmuseum(
 		fm[f.Name] = f
 	}
 	return &chartmuseum{
-		instance:  instance,
-		c:         c,
-		ctx:       ctx,
-		logger:    logger,
-		duration:  duration,
-		cancel:    cancel,
-		scheme:    scheme,
-		repoName:  fmt.Sprintf("%s-%s", instance.GetNamespace(), instance.GetName()),
+		instance: instance,
+		c:        c,
+		ctx:      ctx,
+		logger:   logger,
+		duration: duration,
+		cancel:   cancel,
+		scheme:   scheme,
+		// Note: repoName should be in namepsaced to avoid confilicts when same repo name in different namespaces are used
+		repoName:  instance.NamespacedName(),
 		filterMap: fm,
 	}
 }


### PR DESCRIPTION
1. `ComponentPlan Contoller` and `ChartMuseum watcher` use same repo name (`namespace.name`)

```shell
➜  examples git:(dev) ✗ k ge
➜  examples git:(dev) ✗ helm repo list
NAME                	URL
kubebb-system.kubebb	https://kubebb.github.io/components
➜  examples git:(dev) ✗

```


2. Fix: https://github.com/kubebb/components/issues/28