### PR TITLE
fix: metadata.resourceVersion: Invalid value: 0x0: must be specified …

### DIFF
--- a/pkg/utils/resource.go
+++ b/pkg/utils/resource.go
@@ -126,6 +126,7 @@ func IsNullList(obj *unstructured.Unstructured) bool {
 
 func ResourceDiffStr(ctx context.Context, source, exist *unstructured.Unstructured, ignorePaths []string, c client.Client) (string, error) {
 	newOne := source.DeepCopy()
+	newOne.SetResourceVersion(exist.GetResourceVersion())
 	if err := c.Patch(ctx, newOne, client.MergeFrom(exist), client.DryRunAll); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
…for an update

before this commit:
```yaml
status:
  resources:
    - apiVersion: apiextensions.k8s.io/v1
      kind: CustomResourceDefinition
      name: votes.ibp.com
      specDiffwithExist: diff with exist
```
controller log:

```
1.6885255062837276e+09  ERROR   failed to get diff      {"controller": "componentplan", "controllerGroup": "core.kubebb.k8s.com.cn", "controllerKind": "ComponentPlan", "componentPlan": {"name":"fabric-operator","namespace":"kubebb-system"}, "namespace": "kubebb-system", "name": "fabric-operator", "reconcileID": "f2468d5b-478a-400b-a4e9-5403c5e02c9c", "obj": {"name":"votes.ibp.com"}, "error": "customresourcedefinitions.apiextensions.k8s.io \"votes.ibp.com\" is invalid: metadata.resourceVersion: Invalid value: 0x0: must be specified for an update"}
```

after this commit:
```yaml
status:
  resources:
    - apiVersion: apiextensions.k8s.io/v1
      kind: CustomResourceDefinition
      name: votes.ibp.com
      specDiffwithExist: no spec diff, but some field like resourceVersion will update
``` 

no error log in controller