### PR TITLE
fix: expose port 80&443 for ingress

### DIFF
--- a/tests/kind-config.yaml
+++ b/tests/kind-config.yaml
@@ -3,4 +3,17 @@ apiVersion: kind.x-k8s.io/v1alpha4
 name: kubebb-core
 nodes:
   - role: control-plane
-    image: kindest/node:v1.24.13 # same with go.mod k8s.io/api
+    image: kindest/node:v1.24.13
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+    extraPortMappings:
+      - containerPort: 80
+        hostPort: 80
+        protocol: TCP
+      - containerPort: 443
+        hostPort: 443
+        protocol: TCP


### PR DESCRIPTION
To integrate with building base, port 80&443 should be exposed by default. BTW... single node with building base has been tested on Azure VM