### PR TITLE
fix: set the maximum length of menu names to 64 characters

### DIFF
--- a/api/v1alpha1/menu_types.go
+++ b/api/v1alpha1/menu_types.go
@@ -27,9 +27,13 @@ import (
 type MenuSpec struct {
 	// 菜单组中文名称
 	Id string `json:"id,omitempty"`
-	// 菜单组中文名称
+
+	// 菜单中文名称
+	// +kubebuilder:validation:MaxLength:=64
 	Text string `json:"text,omitempty"`
-	// 菜单组英文名称
+
+	// 菜单英文名称
+	// +kubebuilder:validation:MaxLength:=64
 	TextEn string `json:"textEn"`
 	/** 菜单组所在列序号 */
 	// +optional

--- a/config/crd/bases/core.kubebb.k8s.com.cn_menus.yaml
+++ b/config/crd/bases/core.kubebb.k8s.com.cn_menus.yaml
@@ -108,10 +108,12 @@ spec:
                 description: 菜单对应路由是否可以切换租户
                 type: boolean
               text:
-                description: 菜单组中文名称
+                description: 菜单中文名称
+                maxLength: 64
                 type: string
               textEn:
-                description: 菜单组英文名称
+                description: 菜单英文名称
+                maxLength: 64
                 type: string
               useChildrenReplaceSider:
                 description: 是否在进入子页面后将 sider 替换


### PR DESCRIPTION
fix: set the maximum length of menu names to 64 characters