### PR TITLE
refactor: versioned filter on component ignore

### DIFF
--- a/api/v1alpha1/common_test.go
+++ b/api/v1alpha1/common_test.go
@@ -341,26 +341,25 @@ func TestMatch(t *testing.T) {
 			expected:    nil,
 		},
 		{
-			description: "there is no version filtering information to determine if the chart package is retained or not",
+			description: "the filter is not empty, the chart package is in the filter, but enabled=true, should retain all",
 			name:        "test",
-			filterCond:  map[string]FilterCond{"test": {Deprecated: false, Operation: FilterOpKeep}},
-			versions:    []*hrepo.ChartVersion{{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}}},
+			filterCond:  map[string]FilterCond{"test": {Enabled: false}},
 			keep:        true,
-			expected:    []int{0},
+			expected:    nil,
 		},
 		{
 			description: "there is no version filtering information to determine if the chart package is retained or not",
 			name:        "test",
-			filterCond:  map[string]FilterCond{"test": {Deprecated: false, Operation: FilterOpIgnore}},
+			filterCond:  map[string]FilterCond{"test": {Deprecated: false, Enabled: true}},
 			versions:    []*hrepo.ChartVersion{{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}}},
 			keep:        false,
 			expected:    nil,
 		},
-		// keep,accurate
+		// accurate
 		{
-			description: "accurately matches versions. operation: keep, deprecated: true",
+			description: "accurately matches versions. enabled: true, deprecated: true",
 			name:        "test",
-			filterCond: map[string]FilterCond{"test": {Operation: FilterOpKeep, Deprecated: true, VersionedFilterCond: &VersionedFilterCond{
+			filterCond: map[string]FilterCond{"test": {Enabled: true, Deprecated: true, VersionedFilterCond: &VersionedFilterCond{
 				Versions: []string{"1.0.0", "2.0.0"},
 			}}},
 			versions: []*hrepo.ChartVersion{
@@ -369,24 +368,24 @@ func TestMatch(t *testing.T) {
 				{Metadata: &chart.Metadata{Version: "3.0.0", Deprecated: false}},
 			},
 			keep:     true,
-			expected: []int{0, 1},
+			expected: []int{2},
 		},
 		{
-			description: "accurately matches versions. operation: keep, deprecated: true, no conditions",
+			description: "accurately matches versions. enabled: true, deprecated: true, no conditions",
 			name:        "test",
-			filterCond:  map[string]FilterCond{"test": {Operation: FilterOpKeep, Deprecated: true, VersionedFilterCond: &VersionedFilterCond{}}},
+			filterCond:  map[string]FilterCond{"test": {Enabled: true, Deprecated: true, VersionedFilterCond: &VersionedFilterCond{}}},
 			versions: []*hrepo.ChartVersion{
 				{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}},
 				{Metadata: &chart.Metadata{Version: "2.0.0", Deprecated: false}},
 				{Metadata: &chart.Metadata{Version: "3.0.0", Deprecated: false}},
 			},
-			keep:     false,
-			expected: nil,
+			keep:     true,
+			expected: []int{0, 1, 2},
 		},
 		{
-			description: "accurately matches versions. operation: keep, deprecated: false",
+			description: "accurately matches versions. enabled: true, deprecated: false",
 			name:        "test",
-			filterCond: map[string]FilterCond{"test": {Operation: FilterOpKeep, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{
+			filterCond: map[string]FilterCond{"test": {Enabled: true, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{
 				Versions: []string{"1.0.0", "2.0.0"},
 			}}},
 			versions: []*hrepo.ChartVersion{
@@ -395,12 +394,12 @@ func TestMatch(t *testing.T) {
 				{Metadata: &chart.Metadata{Version: "3.0.0", Deprecated: false}},
 			},
 			keep:     true,
-			expected: []int{1},
+			expected: []int{2},
 		},
 		{
-			description: "accurately matches versions. operation: keep, deprecated: false, no conditions",
+			description: "accurately matches versions. enabled: true, deprecated: false, no conditions",
 			name:        "test",
-			filterCond:  map[string]FilterCond{"test": {Operation: FilterOpKeep, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{}}},
+			filterCond:  map[string]FilterCond{"test": {Enabled: true, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{}}},
 			versions: []*hrepo.ChartVersion{
 				{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}},
 				{Metadata: &chart.Metadata{Version: "2.0.0", Deprecated: true}},
@@ -410,12 +409,12 @@ func TestMatch(t *testing.T) {
 			expected: nil,
 		},
 
-		// keep,regexp
+		// regexp
 		{
-			description: "regexp matches versions. operation: keep, deprecated: true",
+			description: "regexp matches versions. enabled: true, deprecated: true",
 			name:        "test",
-			filterCond: map[string]FilterCond{"test": {Operation: FilterOpKeep, Deprecated: true, VersionedFilterCond: &VersionedFilterCond{
-				VersionRegexp: `^\d\.*0\.0$`,
+			filterCond: map[string]FilterCond{"test": {Enabled: true, Deprecated: true, VersionedFilterCond: &VersionedFilterCond{
+				VersionRegexp: `^((?!\d\.*0\.0).)$`,
 			}}},
 			versions: []*hrepo.ChartVersion{
 				{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}},
@@ -426,10 +425,10 @@ func TestMatch(t *testing.T) {
 			expected: []int{0, 1, 2},
 		},
 		{
-			description: "regexp matches versions. operation: keep, deprecated: false",
+			description: "regexp matches versions. enabled: true, deprecated: false",
 			name:        "test",
-			filterCond: map[string]FilterCond{"test": {Operation: FilterOpKeep, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{
-				VersionRegexp: `^\d\.*0\.0$`,
+			filterCond: map[string]FilterCond{"test": {Enabled: true, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{
+				VersionRegexp: `^((?!\d\.*0\.0).)$`,
 			}}},
 			versions: []*hrepo.ChartVersion{
 				{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}},
@@ -440,10 +439,10 @@ func TestMatch(t *testing.T) {
 			expected: []int{1, 2},
 		},
 		{
-			description: "regexp matches versions. operation: keep, deprecated: false, all deprecated",
+			description: "regexp matches versions. enabled: true, deprecated: false, all deprecated",
 			name:        "test",
-			filterCond: map[string]FilterCond{"test": {Operation: FilterOpKeep, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{
-				VersionRegexp: `^\d\.*0\.0$`,
+			filterCond: map[string]FilterCond{"test": {Enabled: true, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{
+				VersionRegexp: `^((?!\d\.*0\.0).)$`,
 			}}},
 			versions: []*hrepo.ChartVersion{
 				{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}},
@@ -454,10 +453,10 @@ func TestMatch(t *testing.T) {
 			expected: nil,
 		},
 		{
-			description: "regexp matches versions. operation: keep, deprecated: false, version too big",
+			description: "regexp matches versions. enabled: true, deprecated: false, version too big",
 			name:        "test",
-			filterCond: map[string]FilterCond{"test": {Operation: FilterOpKeep, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{
-				VersionRegexp: `^\d\.*0\.0$`,
+			filterCond: map[string]FilterCond{"test": {Enabled: true, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{
+				VersionRegexp: `^((?!\d\.*0\.0).)$`,
 			}}},
 			versions: []*hrepo.ChartVersion{
 				{Metadata: &chart.Metadata{Version: "11.0.0", Deprecated: true}},
@@ -468,179 +467,11 @@ func TestMatch(t *testing.T) {
 			expected: nil,
 		},
 
-		// keep, semvar
+		// semvar
 		{
-			description: "semvar matches versions. operation: keep, deprecated: true",
+			description: "semvar matches versions. enabled: true, deprecated: true",
 			name:        "test",
-			filterCond: map[string]FilterCond{"test": {Operation: FilterOpKeep, Deprecated: true, VersionedFilterCond: &VersionedFilterCond{
-				VersionConstraint: ">= 2.0.0",
-			}}},
-			versions: []*hrepo.ChartVersion{
-				{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}},
-				{Metadata: &chart.Metadata{Version: "2.0.0", Deprecated: true}},
-				{Metadata: &chart.Metadata{Version: "3.0.0", Deprecated: false}},
-			},
-			keep:     true,
-			expected: []int{1, 2},
-		},
-		{
-			description: "semvar matches versions. operation: keep, deprecated: false",
-			name:        "test",
-			filterCond: map[string]FilterCond{"test": {Operation: FilterOpKeep, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{
-				VersionConstraint: ">= 2.0.0",
-			}}},
-			versions: []*hrepo.ChartVersion{
-				{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}},
-				{Metadata: &chart.Metadata{Version: "2.0.0", Deprecated: true}},
-				{Metadata: &chart.Metadata{Version: "3.0.0", Deprecated: false}},
-			},
-			keep:     true,
-			expected: []int{2},
-		},
-		{
-			description: "semvar matches versions. operation: keep, deprecated: false, all deprecated",
-			name:        "test",
-			filterCond: map[string]FilterCond{"test": {Operation: FilterOpKeep, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{
-				VersionConstraint: ">= 1.0.0",
-			}}},
-			versions: []*hrepo.ChartVersion{
-				{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}},
-				{Metadata: &chart.Metadata{Version: "2.0.0", Deprecated: true}},
-				{Metadata: &chart.Metadata{Version: "3.0.0", Deprecated: true}},
-			},
-			keep:     false,
-			expected: nil,
-		},
-		{
-			description: "semvar matches versions. operation: keep, deprecated: false, no conditions",
-			name:        "test",
-			filterCond:  map[string]FilterCond{"test": {Operation: FilterOpKeep, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{}}},
-			versions: []*hrepo.ChartVersion{
-				{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}},
-				{Metadata: &chart.Metadata{Version: "2.0.0", Deprecated: true}},
-				{Metadata: &chart.Metadata{Version: "3.0.0", Deprecated: true}},
-			},
-			keep:     false,
-			expected: nil,
-		},
-
-		// ignore, accurately
-		{
-			description: "accurately matches versions. operation: ignore, deprecated: true",
-			name:        "test",
-			filterCond: map[string]FilterCond{"test": {Operation: FilterOpIgnore, Deprecated: true, VersionedFilterCond: &VersionedFilterCond{
-				Versions: []string{"1.0.0", "2.0.0"},
-			}}},
-			versions: []*hrepo.ChartVersion{
-				{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}},
-				{Metadata: &chart.Metadata{Version: "2.0.0", Deprecated: false}},
-				{Metadata: &chart.Metadata{Version: "3.0.0", Deprecated: false}},
-			},
-			keep:     true,
-			expected: []int{2},
-		},
-		{
-			description: "accurately matches versions. operation: ignore, deprecated: true, no conditions",
-			name:        "test",
-			filterCond:  map[string]FilterCond{"test": {Operation: FilterOpIgnore, Deprecated: true, VersionedFilterCond: &VersionedFilterCond{}}},
-			versions: []*hrepo.ChartVersion{
-				{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}},
-				{Metadata: &chart.Metadata{Version: "2.0.0", Deprecated: false}},
-				{Metadata: &chart.Metadata{Version: "3.0.0", Deprecated: false}},
-			},
-			keep:     true,
-			expected: []int{0, 1, 2},
-		},
-		{
-			description: "accurately matches versions. operation: ignore, deprecated: false",
-			name:        "test",
-			filterCond: map[string]FilterCond{"test": {Operation: FilterOpIgnore, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{
-				Versions: []string{"1.0.0", "2.0.0"},
-			}}},
-			versions: []*hrepo.ChartVersion{
-				{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}},
-				{Metadata: &chart.Metadata{Version: "2.0.0", Deprecated: false}},
-				{Metadata: &chart.Metadata{Version: "3.0.0", Deprecated: false}},
-			},
-			keep:     true,
-			expected: []int{2},
-		},
-		{
-			description: "accurately matches versions. operation: ignore, deprecated: true, no conditions",
-			name:        "test",
-			filterCond:  map[string]FilterCond{"test": {Operation: FilterOpIgnore, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{}}},
-			versions: []*hrepo.ChartVersion{
-				{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}},
-				{Metadata: &chart.Metadata{Version: "2.0.0", Deprecated: true}},
-				{Metadata: &chart.Metadata{Version: "3.0.0", Deprecated: true}},
-			},
-			keep:     false,
-			expected: nil,
-		},
-
-		// ignore, regexp
-		{
-			description: "regexp matches versions. operation: ignore, deprecated: true",
-			name:        "test",
-			filterCond: map[string]FilterCond{"test": {Operation: FilterOpIgnore, Deprecated: true, VersionedFilterCond: &VersionedFilterCond{
-				VersionRegexp: `^\d\.*0\.0$`,
-			}}},
-			versions: []*hrepo.ChartVersion{
-				{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}},
-				{Metadata: &chart.Metadata{Version: "2.0.0", Deprecated: false}},
-				{Metadata: &chart.Metadata{Version: "3.0.0", Deprecated: false}},
-			},
-			keep:     false,
-			expected: nil,
-		},
-		{
-			description: "regexp matches versions. operation: ignore, deprecated: false",
-			name:        "test",
-			filterCond: map[string]FilterCond{"test": {Operation: FilterOpIgnore, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{
-				VersionRegexp: `^\d\.*0\.0$`,
-			}}},
-			versions: []*hrepo.ChartVersion{
-				{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}},
-				{Metadata: &chart.Metadata{Version: "2.0.0", Deprecated: false}},
-				{Metadata: &chart.Metadata{Version: "3.0.0", Deprecated: false}},
-			},
-			keep:     false,
-			expected: nil,
-		},
-		{
-			description: "regexp matches versions. operation: ignore, deprecated: false, all deprecated",
-			name:        "test",
-			filterCond: map[string]FilterCond{"test": {Operation: FilterOpIgnore, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{
-				VersionRegexp: `^\d\.*0\.0$`,
-			}}},
-			versions: []*hrepo.ChartVersion{
-				{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}},
-				{Metadata: &chart.Metadata{Version: "2.0.0", Deprecated: true}},
-				{Metadata: &chart.Metadata{Version: "3.0.0", Deprecated: true}},
-			},
-			keep:     false,
-			expected: nil,
-		},
-		{
-			description: "regexp matches versions. operation: ignore, deprecated: true, too big version",
-			name:        "test",
-			filterCond: map[string]FilterCond{"test": {Operation: FilterOpIgnore, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{
-				VersionRegexp: `^\d\.*0\.0$`,
-			}}},
-			versions: []*hrepo.ChartVersion{
-				{Metadata: &chart.Metadata{Version: "11.0.0", Deprecated: true}},
-				{Metadata: &chart.Metadata{Version: "21.0.0", Deprecated: true}},
-				{Metadata: &chart.Metadata{Version: "31.0.0", Deprecated: true}},
-			},
-			keep:     false,
-			expected: nil,
-		},
-
-		// ignore, semvar
-		{
-			description: "semvar matches versions. operation: ignore, deprecated: true",
-			name:        "test",
-			filterCond: map[string]FilterCond{"test": {Operation: FilterOpIgnore, Deprecated: true, VersionedFilterCond: &VersionedFilterCond{
+			filterCond: map[string]FilterCond{"test": {Enabled: true, Deprecated: true, VersionedFilterCond: &VersionedFilterCond{
 				VersionConstraint: ">= 2.0.0",
 			}}},
 			versions: []*hrepo.ChartVersion{
@@ -652,9 +483,9 @@ func TestMatch(t *testing.T) {
 			expected: []int{0},
 		},
 		{
-			description: "semvar matches versions. operation: ignore, deprecated: false",
+			description: "semvar matches versions. enabled: true, deprecated: false",
 			name:        "test",
-			filterCond: map[string]FilterCond{"test": {Operation: FilterOpIgnore, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{
+			filterCond: map[string]FilterCond{"test": {Enabled: true, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{
 				VersionConstraint: ">= 2.0.0",
 			}}},
 			versions: []*hrepo.ChartVersion{
@@ -666,9 +497,9 @@ func TestMatch(t *testing.T) {
 			expected: nil,
 		},
 		{
-			description: "semvar matches versions. operation: ignore, deprecated: true, all deprecated",
+			description: "semvar matches versions. enabled: true, deprecated: false, all deprecated",
 			name:        "test",
-			filterCond: map[string]FilterCond{"test": {Operation: FilterOpIgnore, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{
+			filterCond: map[string]FilterCond{"test": {Enabled: true, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{
 				VersionConstraint: ">= 1.0.0",
 			}}},
 			versions: []*hrepo.ChartVersion{
@@ -680,9 +511,191 @@ func TestMatch(t *testing.T) {
 			expected: nil,
 		},
 		{
-			description: "semvar matches versions. operation: ignore, deprecated: true, no conditions",
+			description: "semvar matches versions. enabled: true, deprecated: false, no conditions",
 			name:        "test",
-			filterCond:  map[string]FilterCond{"test": {Operation: FilterOpIgnore, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{}}},
+			filterCond:  map[string]FilterCond{"test": {Enabled: true, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{}}},
+			versions: []*hrepo.ChartVersion{
+				{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}},
+				{Metadata: &chart.Metadata{Version: "2.0.0", Deprecated: true}},
+				{Metadata: &chart.Metadata{Version: "3.0.0", Deprecated: true}},
+			},
+			keep:     false,
+			expected: nil,
+		},
+
+		// accurately
+		{
+			description: "accurately matches versions. enabled: true, deprecated: true",
+			name:        "test",
+			filterCond: map[string]FilterCond{"test": {Enabled: true, Deprecated: true, VersionedFilterCond: &VersionedFilterCond{
+				Versions: []string{"1.0.0", "2.0.0"},
+			}}},
+			versions: []*hrepo.ChartVersion{
+				{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}},
+				{Metadata: &chart.Metadata{Version: "2.0.0", Deprecated: false}},
+				{Metadata: &chart.Metadata{Version: "3.0.0", Deprecated: false}},
+			},
+			keep:     true,
+			expected: []int{2},
+		},
+		{
+			description: "accurately matches versions. enabled: true, deprecated: true, no conditions",
+			name:        "test",
+			filterCond:  map[string]FilterCond{"test": {Enabled: true, Deprecated: true, VersionedFilterCond: &VersionedFilterCond{}}},
+			versions: []*hrepo.ChartVersion{
+				{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}},
+				{Metadata: &chart.Metadata{Version: "2.0.0", Deprecated: false}},
+				{Metadata: &chart.Metadata{Version: "3.0.0", Deprecated: false}},
+			},
+			keep:     true,
+			expected: []int{0, 1, 2},
+		},
+		{
+			description: "accurately matches versions. enabled: true, deprecated: false",
+			name:        "test",
+			filterCond: map[string]FilterCond{"test": {Enabled: true, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{
+				Versions: []string{"1.0.0", "2.0.0"},
+			}}},
+			versions: []*hrepo.ChartVersion{
+				{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}},
+				{Metadata: &chart.Metadata{Version: "2.0.0", Deprecated: false}},
+				{Metadata: &chart.Metadata{Version: "3.0.0", Deprecated: false}},
+			},
+			keep:     true,
+			expected: []int{2},
+		},
+		{
+			description: "accurately matches versions. enabled: true, deprecated: true, no conditions",
+			name:        "test",
+			filterCond:  map[string]FilterCond{"test": {Enabled: true, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{}}},
+			versions: []*hrepo.ChartVersion{
+				{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}},
+				{Metadata: &chart.Metadata{Version: "2.0.0", Deprecated: true}},
+				{Metadata: &chart.Metadata{Version: "3.0.0", Deprecated: true}},
+			},
+			keep:     false,
+			expected: nil,
+		},
+
+		// regexp
+		{
+			description: "regexp matches versions. enabled: true, deprecated: true",
+			name:        "test",
+			filterCond: map[string]FilterCond{"test": {Enabled: true, Deprecated: true, VersionedFilterCond: &VersionedFilterCond{
+				VersionRegexp: `^\d\.*0\.0$`,
+			}}},
+			versions: []*hrepo.ChartVersion{
+				{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}},
+				{Metadata: &chart.Metadata{Version: "2.0.0", Deprecated: false}},
+				{Metadata: &chart.Metadata{Version: "3.0.0", Deprecated: false}},
+			},
+			keep:     false,
+			expected: nil,
+		},
+		{
+			description: "regexp matches versions. enabled: true, deprecated: false",
+			name:        "test",
+			filterCond: map[string]FilterCond{"test": {Enabled: true, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{
+				VersionRegexp: `^\d\.*0\.0$`,
+			}}},
+			versions: []*hrepo.ChartVersion{
+				{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}},
+				{Metadata: &chart.Metadata{Version: "2.0.0", Deprecated: false}},
+				{Metadata: &chart.Metadata{Version: "3.0.0", Deprecated: false}},
+			},
+			keep:     false,
+			expected: nil,
+		},
+		{
+			description: "regexp matches versions. enabled: true, deprecated: false, all deprecated",
+			name:        "test",
+			filterCond: map[string]FilterCond{"test": {Enabled: true, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{
+				VersionRegexp: `^\d\.*0\.0$`,
+			}}},
+			versions: []*hrepo.ChartVersion{
+				{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}},
+				{Metadata: &chart.Metadata{Version: "2.0.0", Deprecated: true}},
+				{Metadata: &chart.Metadata{Version: "3.0.0", Deprecated: true}},
+			},
+			keep:     false,
+			expected: nil,
+		},
+		{
+			description: "regexp matches versions. enabled: true, deprecated: true, too big version",
+			name:        "test",
+			filterCond: map[string]FilterCond{"test": {Enabled: true, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{
+				VersionRegexp: `^\d\.*0\.0$`,
+			}}},
+			versions: []*hrepo.ChartVersion{
+				{Metadata: &chart.Metadata{Version: "11.0.0", Deprecated: true}},
+				{Metadata: &chart.Metadata{Version: "21.0.0", Deprecated: true}},
+				{Metadata: &chart.Metadata{Version: "31.0.0", Deprecated: true}},
+			},
+			keep:     false,
+			expected: nil,
+		},
+
+		// semvar
+		{
+			description: "semvar matches versions. enabled: true, deprecated: true",
+			name:        "test",
+			filterCond: map[string]FilterCond{"test": {Enabled: true, Deprecated: true, VersionedFilterCond: &VersionedFilterCond{
+				VersionConstraint: ">= 2.0.0",
+			}}},
+			versions: []*hrepo.ChartVersion{
+				{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}},
+				{Metadata: &chart.Metadata{Version: "2.0.0", Deprecated: true}},
+				{Metadata: &chart.Metadata{Version: "3.0.0", Deprecated: false}},
+			},
+			keep:     true,
+			expected: []int{0},
+		},
+		{
+			description: "semvar matches versions. enabled: true, deprecated: false",
+			name:        "test",
+			filterCond: map[string]FilterCond{"test": {Enabled: true, Deprecated: true, VersionedFilterCond: &VersionedFilterCond{
+				VersionConstraint: "< 2.0.0",
+			}}},
+			versions: []*hrepo.ChartVersion{
+				{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}},
+				{Metadata: &chart.Metadata{Version: "2.0.0", Deprecated: true}},
+				{Metadata: &chart.Metadata{Version: "3.0.0", Deprecated: false}},
+			},
+			keep:     true,
+			expected: []int{1, 2},
+		},
+		{
+			description: "semvar matches versions. enabled: true, deprecated: false",
+			name:        "test",
+			filterCond: map[string]FilterCond{"test": {Enabled: true, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{
+				VersionConstraint: ">= 2.0.0",
+			}}},
+			versions: []*hrepo.ChartVersion{
+				{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}},
+				{Metadata: &chart.Metadata{Version: "2.0.0", Deprecated: true}},
+				{Metadata: &chart.Metadata{Version: "3.0.0", Deprecated: false}},
+			},
+			keep:     false,
+			expected: nil,
+		},
+		{
+			description: "semvar matches versions. enabled: true, deprecated: true, all deprecated",
+			name:        "test",
+			filterCond: map[string]FilterCond{"test": {Enabled: true, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{
+				VersionConstraint: ">= 1.0.0",
+			}}},
+			versions: []*hrepo.ChartVersion{
+				{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}},
+				{Metadata: &chart.Metadata{Version: "2.0.0", Deprecated: true}},
+				{Metadata: &chart.Metadata{Version: "3.0.0", Deprecated: true}},
+			},
+			keep:     false,
+			expected: nil,
+		},
+		{
+			description: "semvar matches versions. enabled: true, deprecated: true, no conditions",
+			name:        "test",
+			filterCond:  map[string]FilterCond{"test": {Enabled: true, Deprecated: false, VersionedFilterCond: &VersionedFilterCond{}}},
 			versions: []*hrepo.ChartVersion{
 				{Metadata: &chart.Metadata{Version: "1.0.0", Deprecated: true}},
 				{Metadata: &chart.Metadata{Version: "2.0.0", Deprecated: true}},

--- a/api/v1alpha1/repository_types.go
+++ b/api/v1alpha1/repository_types.go
@@ -20,13 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type FilterOp string
-
-const (
-	FilterOpKeep   FilterOp = "keep"
-	FilterOpIgnore FilterOp = "ignore"
-)
-
 // PullStategy for pulling components in repository
 type PullStategy struct {
 	// Interval for pulling
@@ -54,10 +47,9 @@ type FilterCond struct {
 	// Name of the component
 	Name string `json:"name,omitempty"`
 
-	// default is keep
-	// +kubebuilder:validation:Enum=keep;ignore
-	// +kubebuilder:default:=keep
-	Operation FilterOp `json:"operation,omitempty"`
+	// Enable filtering on the component,
+	// if false, no action will be taken on the component, in other worlds, all versions of the component will be retained.
+	Enabled bool `json:"enabled,omitempty"`
 
 	// If True, the current version will be retained even if it is deprecated.
 	Deprecated bool `json:"deprecated,omitempty"`

--- a/config/crd/bases/core.kubebb.k8s.com.cn_repositories.yaml
+++ b/config/crd/bases/core.kubebb.k8s.com.cn_repositories.yaml
@@ -50,15 +50,13 @@ spec:
                       description: If True, the current version will be retained even
                         if it is deprecated.
                       type: boolean
+                    enabled:
+                      description: Enable filtering on the component, if false, no
+                        action will be taken on the component, in other worlds, all
+                        versions of the component will be retained.
+                      type: boolean
                     name:
                       description: Name of the component
-                      type: string
-                    operation:
-                      default: keep
-                      description: default is keep
-                      enum:
-                      - keep
-                      - ignore
                       type: string
                     versionedFilterCond:
                       description: VersionedFilterCond filters which version in component


### PR DESCRIPTION
Fix #96 

Replace filter.operation with filter.enabled.

![image](https://github.com/kubebb/core/assets/17400942/6e7a7af5-27e6-40b3-a0d9-374df8827c5a)
