### PR TITLE
fix: helm action concurrency issues

### DIFF
--- a/.github/workflows/example_test.yaml
+++ b/.github/workflows/example_test.yaml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        no: [1, 2, 3, 4, 5]
+        no: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     steps:
       - uses: actions/checkout@v3
       - name: Download operator image from cache

--- a/pkg/helm/cmd.go
+++ b/pkg/helm/cmd.go
@@ -18,6 +18,7 @@ package helm
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
 	corev1alpha1 "github.com/kubebb/core/api/v1alpha1"
@@ -83,14 +84,14 @@ func installOrUpgrade(ctx context.Context, getter genericclioptions.RESTClientGe
 		if err != nil {
 			return nil, err
 		}
-		logger.Info("install completed", ReleaseLog(rel)...)
+		logger.Info(fmt.Sprintf("helm install completed dryRun:%t", dryRun), ReleaseLog(rel)...)
 	} else {
-		logger.Info("find last release", ReleaseLog(rel)...)
+		logger.Info("helm find last release", ReleaseLog(rel)...)
 		rel, err = h.upgrade(ctx, logger, cli, cpl, repo, dryRun, chartName)
 		if err != nil {
 			return nil, err
 		}
-		logger.Info("upgrade completed", ReleaseLog(rel)...)
+		logger.Info(fmt.Sprintf("upgrade completed dryRun:%t", dryRun), ReleaseLog(rel)...)
 	}
 	return rel, nil
 }

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -109,7 +109,7 @@ func (h *HelmWrapper) install(ctx context.Context, logger logr.Logger, cli clien
 	if err != nil {
 		return nil, err
 	}
-	i.Namespace = settings.Namespace()
+	i.Namespace = cpl.Namespace
 	return i.RunWithContext(ctx, chartRequested, vals)
 }
 
@@ -157,7 +157,7 @@ func (h *HelmWrapper) upgrade(ctx context.Context, logger logr.Logger, cli clien
 	if err != nil {
 		return nil, err
 	}
-	i.Namespace = settings.Namespace()
+	i.Namespace = cpl.Namespace
 	return i.RunWithContext(ctx, cpl.GetReleaseName(), chartRequested, vals)
 }
 


### PR DESCRIPTION
- add syncMap and reduce unnecessary retry reconcile request (Fix #126) prevents multiple installations（Neither cpl.status nor helm releases are real-time, and there will be edge-case errors with these two judgments, but they can be used as a judgment condition after operator restarts) (xref #85)
- simplify componentplan's patchStatus function
- helm log update, fix helm installation ns (Fix #105)
- increase the concurrency of example-test from 5 to 10
- fix the problem in example-test and add the verification of helm revision after componentplan installation.

Fix https://github.com/kubebb/core/actions/runs/5585781404/jobs/10209054157#step:6:140 and https://github.com/kubebb/core/actions/runs/5595656655/jobs/10231821540