### PR TITLE
refactor: versioned filter on component ignore

### DIFF
--- a/api/v1alpha1/repository_types.go
+++ b/api/v1alpha1/repository_types.go
@@ -20,6 +20,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+type FilterOp string
+
+const (
+	FilterOpKeep   FilterOp = "keep"
+	FilterOpIgnore FilterOp = "ignore"
+)
+
 // PullStategy for pulling components in repository
 type PullStategy struct {
 	// Interval for pulling
@@ -47,12 +54,13 @@ type FilterCond struct {
 	// Name of the component
 	Name string `json:"name,omitempty"`
 
-	// Enable filtering on the component,
-	// if false, no action will be taken on the component, in other worlds, all versions of the component will be retained.
-	Enabled bool `json:"enabled,omitempty"`
+	// default is keep
+	// +kubebuilder:validation:Enum=keep;ignore
+	// +kubebuilder:default:=keep
+	Operation FilterOp `json:"operation,omitempty"`
 
 	// If True, the current version will be retained even if it is deprecated.
-	Deprecated bool `json:"deprecated,omitempty"`
+	KeepDeprecated bool `json:"keepDeprecated,omitempty"`
 
 	// VersionedFilterCond filters which version in component are pulled/ignored from the repository
 	VersionedFilterCond *VersionedFilterCond `json:"versionedFilterCond,omitempty"`

--- a/config/crd/bases/core.kubebb.k8s.com.cn_repositories.yaml
+++ b/config/crd/bases/core.kubebb.k8s.com.cn_repositories.yaml
@@ -46,17 +46,19 @@ spec:
               filter:
                 items:
                   properties:
-                    deprecated:
+                    keepDeprecated:
                       description: If True, the current version will be retained even
                         if it is deprecated.
                       type: boolean
-                    enabled:
-                      description: Enable filtering on the component, if false, no
-                        action will be taken on the component, in other worlds, all
-                        versions of the component will be retained.
-                      type: boolean
                     name:
                       description: Name of the component
+                      type: string
+                    operation:
+                      default: keep
+                      description: default is keep
+                      enum:
+                      - keep
+                      - ignore
                       type: string
                     versionedFilterCond:
                       description: VersionedFilterCond filters which version in component


### PR DESCRIPTION
Fix #96 

According to the PM's design, the final decision is to use the `operation` field, with the available values of `keep` and `ignore`.

<img width="577" alt="image" src="https://github.com/kubebb/core/assets/17400942/20206128-3199-49b4-8c43-b0824e208877">

![image](https://github.com/kubebb/core/assets/17400942/9d65e126-29f3-4486-8417-bc99f8e05e78)
