### PR TITLE
feat: add cpl config: cleanupOnFail and keepHistory, matches to the helm install/upgrade/uninstall args

### DIFF
--- a/config/crd/bases/core.kubebb.k8s.com.cn_componentplans.yaml
+++ b/config/crd/bases/core.kubebb.k8s.com.cn_componentplans.yaml
@@ -47,6 +47,11 @@ spec:
                   the installation process deletes the installation on failure. The
                   --wait flag will be set automatically if --atomic is used
                 type: boolean
+              cleanupOnFail:
+                description: CleanupOnFail is pass to helm upgrade --cleanup-on-fail
+                  allow deletion of new resources created in this upgrade when upgrade
+                  fails
+                type: boolean
               component:
                 description: ComponentRef is a reference to the Component
                 properties:
@@ -115,6 +120,11 @@ spec:
                   the maximum number of revisions saved per release. Use 0 for no
                   limit
                 type: integer
+              keepHistory:
+                description: KeepHistory is paas to helm uninstall --keep-history
+                  remove all associated resources and mark the release as deleted,
+                  but retain the release history.
+                type: boolean
               maxRetry:
                 description: MaxRetry
                 type: integer

--- a/config/crd/bases/core.kubebb.k8s.com.cn_subscriptions.yaml
+++ b/config/crd/bases/core.kubebb.k8s.com.cn_subscriptions.yaml
@@ -43,6 +43,11 @@ spec:
                   the installation process deletes the installation on failure. The
                   --wait flag will be set automatically if --atomic is used
                 type: boolean
+              cleanupOnFail:
+                description: CleanupOnFail is pass to helm upgrade --cleanup-on-fail
+                  allow deletion of new resources created in this upgrade when upgrade
+                  fails
+                type: boolean
               component:
                 description: ComponentRef is a reference to the Component
                 properties:
@@ -115,6 +120,11 @@ spec:
                   the maximum number of revisions saved per release. Use 0 for no
                   limit
                 type: integer
+              keepHistory:
+                description: KeepHistory is paas to helm uninstall --keep-history
+                  remove all associated resources and mark the release as deleted,
+                  but retain the release history.
+                type: boolean
               maxRetry:
                 description: MaxRetry
                 type: integer

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -138,8 +138,8 @@ func (h *HelmWrapper) upgrade(ctx context.Context, logger logr.Logger, cli clien
 	i.WaitForJobs = cpl.Spec.WaitForJobs
 	i.Atomic = cpl.Spec.Atomic
 	i.MaxHistory = cpl.Spec.GetMaxHistory()
-	i.CleanupOnFail = false // TODO: do we need add this args to override?
-	i.SubNotes = false      // we cant see notes or subnotes
+	i.CleanupOnFail = cpl.Spec.CleanupOnFail
+	i.SubNotes = false // we cant see notes or subnotes
 	i.Description = cpl.Spec.Description
 	i.DependencyUpdate = true
 
@@ -171,7 +171,7 @@ func (h *HelmWrapper) uninstall(logger logr.Logger, cpl *corev1alpha1.ComponentP
 	i := action.NewUninstall(h.config)
 	i.DryRun = false // do not need to simulate the installation
 	i.DisableHooks = cpl.Spec.DisableHooks
-	i.KeepHistory = false // TODO: do we need add this args to override?
+	i.KeepHistory = cpl.Spec.KeepHistory
 	i.Timeout = cpl.Spec.Timeout()
 	i.Wait = cpl.Spec.Wait
 	res, err := i.Run(cpl.GetReleaseName())


### PR DESCRIPTION
We have compared all the helm install/upgrade/uninstall parameters, and there are 3 scenarios:
1. It is configurable in cpl config.
2. We don't support the configuration, the reason also appears in the comment of the config field and also in the crd of the cpl.
3. We are not sure if we want to support it now, the TODO appears in the comment of the config field

Signed-off-by: Abirdcfly <fp544037857@gmail.com>
