### PR TITLE
fix: repository events are not updated

### DIFF
--- a/api/v1alpha1/condition.go
+++ b/api/v1alpha1/condition.go
@@ -87,7 +87,9 @@ func (c Condition) Equal(other Condition) bool {
 	return c.Type == other.Type &&
 		c.Status == other.Status &&
 		c.Reason == other.Reason &&
-		c.Message == other.Message
+		c.Message == other.Message &&
+		c.LastSuccessfulTime.Equal(&other.LastSuccessfulTime) &&
+		c.LastTransitionTime.Equal(&other.LastTransitionTime)
 }
 
 // WithMessage returns a condition by adding the provided message to existing


### PR DESCRIPTION
fix: repository events are not updated

At present, if the continuous synchronization `succeeds` or `fails`, the `Message`, `Reason`, `Type`, and `Status` fields do not change, and the `LastTransitionTime` and `LastSuccessfulTime` cannot be set normally.