### PR TITLE
fix: should use kubebb-core instead of kubebb as the chart name

### DIFF
--- a/config/samples/example-test.sh
+++ b/config/samples/example-test.sh
@@ -347,9 +347,9 @@ helm repo add kubebb https://kubebb.github.io/components
 helm repo update kubebb
 
 info "2.2 search kubebb"
-search_result=$(helm search repo kubebb/kubebb)
+search_result=$(helm search repo kubebb/kubebb-core)
 if [[ $search_result == "No results found" ]]; then
-	error "not found chart kubebb/kubebb"
+	error "not found chart kubebb/kubebb-core"
 	exit 1
 fi
 
@@ -360,7 +360,7 @@ kubectl create ns kubebb-system
 info "2.3.2 create kubebb release"
 docker tag kubebb/core:latest kubebb/core:example-e2e
 kind load docker-image kubebb/core:example-e2e
-helm -nkubebb-system install kubebb kubebb/kubebb --set deployment.image=kubebb/core:example-e2e --wait
+helm -nkubebb-system install kubebb kubebb/kubebb-core --set deployment.image=kubebb/core:example-e2e --wait
 cd ${RootPath}
 kubectl kustomize config/crd | kubectl apply -f -
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubebb/core/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

We are using a wrong chart name during example-test

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer

Our chart name has been renamed to `kubebb-core` since `v0.1.0`
https://github.com/kubebb/components/commit/73aa11413dadd757518026fd6bcccf112133bb25
