### PR TITLE
test: skip install kustomize to avoid Github rate-limiter failure

### DIFF
--- a/.github/workflows/example_test.yaml
+++ b/.github/workflows/example_test.yaml
@@ -70,7 +70,12 @@ jobs:
             /home/runner/work/kubebb-core/kubebb-core/tmp/all.image.list
       - name: Load kubebb core image to docker
         run: |
-         docker load --input /tmp/operator.image.tar
+          docker load --input /tmp/operator.image.tar
+      - name: Copy the existing kustomize
+        # avoid kustomize installation to bypass the rate limit of GitHub.
+        run: |
+          mkdir -p ${GITHUB_WORKSPACE}/bin 
+          cp /usr/local/bin/kustomize ${GITHUB_WORKSPACE}/bin/kustomize
       - name: Example test
         run: config/samples/example-test.sh
       - name: Upload logs if test fail


### PR DESCRIPTION
fix issue like https://github.com/kubebb/core/actions/runs/5937625058/job/16100509925#step:6:90
```
/home/runner/work/core/core/bin/controller-gen rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
test -s /home/runner/work/core/core/bin/kustomize || { curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s -- 3.8.7 /home/runner/work/core/core/bin; }
Github rate-limiter failed the request. Either authenticate or wait a couple of minutes.
make: *** [Makefile:195: /home/runner/work/core/core/bin/kustomize] Error 1
```
