### PR TITLE
fix: oci repo has no digest

### DIFF
--- a/config/samples/example-test.sh
+++ b/config/samples/example-test.sh
@@ -131,8 +131,6 @@ function waitComponentStatus() {
 		versions=$(kubectl -n${namespace} get components.core.kubebb.k8s.com.cn ${componentName} -ojson | jq -r '.status.versions|length')
 		if [[ $versions -ne 0 ]]; then
 			echo "component ${componentName} already have version information and can be installed"
-			#			digest=$(kubectl -n${namespace} get components.core.kubebb.k8s.com.cn ${componentName} -ojson | jq -r '.status.versions.digest')
-			#			echo "digest: ${digest}"
 			break
 		fi
 		CURRENT_TIME=$(date +%s)
@@ -561,6 +559,13 @@ info "7 try to verify that the common steps are valid to oci types"
 info "7.1 create oci repository"
 kubectl apply -f config/samples/core_v1alpha1_repository_oci.yaml
 waitComponentStatus "kubebb-system" "repository-oci-sample.nginx"
+oci_digest=$(kubectl -n${namespace} get components ${componentName} -ojson | jq -r '.status.versions[0].digest')
+fixed_nginx_digest="d9459e1206a4f5a8e0d7c5da8a306ab9b1ba5d7182ae671610b5699250ea45f8"
+echo "digest: ${oci_digest}"
+if [[ ${oci_digest} != ${fixed_nginx_digest} ]]; then
+	echo "digest has wrong value"
+	exit 1
+fi
 
 info "7.2 create oci componentplan"
 kubectl apply -f config/samples/core_v1alpha1_oci_componentplan.yaml

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -108,3 +108,49 @@ func TestParseDescription(t *testing.T) {
 		})
 	}
 }
+
+func TestParseDigestFromPullOut(t *testing.T) {
+	type args struct {
+		out string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "normal oci",
+			args: args{
+				out: `Pulled: registry-1.docker.io/bitnamicharts/nginx:15.0.2
+Digest: sha256:32d95bdf27824295fcb8a9f7dd8e2b001524a9181d514076586f90565e986401
+				`,
+			},
+			want: "32d95bdf27824295fcb8a9f7dd8e2b001524a9181d514076586f90565e986401",
+		},
+		{
+			name: "normal http",
+			args: args{
+				out: `
+				`,
+			},
+			want: "",
+		},
+		{
+			name: "normal oci with extra output",
+			args: args{
+				out: `Pulled: registry-1.docker.io/bitnamicharts/nginx:15.0.2
+Digest: sha256:32d95bdf27824295fcb8a9f7dd8e2b001524a9181d514076586f90565e986401
+Error: failed to untar: a file or directory with the name nginx already exists
+				`,
+			},
+			want: "32d95bdf27824295fcb8a9f7dd8e2b001524a9181d514076586f90565e986401",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ParseDigestFromPullOut(tt.args.out); got != tt.want {
+				t.Errorf("ParseDigestFromPullOut() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/repository/oci_watcher.go
+++ b/pkg/repository/oci_watcher.go
@@ -130,7 +130,8 @@ func (c *OCIWatcher) Poll() {
 	if err != nil {
 		c.logger.Error(err, "Cannot create a new helm wrapper")
 	}
-	info, err := h.Pull(c.logger, c.instance.Spec.URL)
+	out, info, err := h.Pull(c.logger, c.instance.Spec.URL)
+
 	if err != nil {
 		c.logger.Error(err, "Cannot pull chart")
 		return
@@ -178,7 +179,7 @@ func (c *OCIWatcher) Poll() {
 		Version:    versions.Version,
 		AppVersion: versions.AppVersion,
 		CreatedAt:  metav1.Now(), //TODO: metav1.NewTime(versions.Created),
-		//Digest:     digest, //TODO: Set digest
+		Digest:     helm.ParseDigestFromPullOut(out),
 		UpdatedAt:  metav1.Now(),
 		Deprecated: versions.Deprecated,
 	})


### PR DESCRIPTION
Fix #252 

```bash
$ helm pull oci://registry-1.docker.io/bitnamicharts/nginx --version 15.0.2
Pulled: registry-1.docker.io/bitnamicharts/nginx:15.0.2
Digest: sha256:32d95bdf27824295fcb8a9f7dd8e2b001524a9181d514076586f90565e986401
```
It is same with https://hub.docker.com/r/bitnamicharts/nginx/tags?page=1&name=15.0.2
![CleanShot 2023-08-25 at 09 36 29](https://github.com/kubebb/core/assets/5100555/a7252675-36d9-4fb3-bb41-3c592f60d68d)

we can use this digest for oci repo.